### PR TITLE
Fix document-relative URIs in ns.rdf

### DIFF
--- a/cc/licenserdf/rdf/ns.html
+++ b/cc/licenserdf/rdf/ns.html
@@ -15,7 +15,7 @@
 
     <title>Describing Copyright in RDF - Creative Commons Rights Expression Language</title>
 
-    <base href="https://creativecommons.org/ns" />
+    <base href="http://creativecommons.org/ns" />
 
     <link rel="stylesheet" type="text/css" 
 	  href="/includes/bootstrap.min.css" />
@@ -271,7 +271,7 @@
 	    <div id="legalcode" about="#legalcode" 
 		 typeof="rdf:Property">
 	      <h4>cc:legalcode</h4> The <a rel="rdfs:range"
-		                           href="//www.w3.org/2000/01/rdf-schema#Resource">
+		                           href="http://www.w3.org/2000/01/rdf-schema#Resource">
 		URL</a> of the legal text of a <a rel="rdfs:domain"
 		                                  href="#License">License</a>.
 	    </div>
@@ -281,7 +281,7 @@
 	      <h4>cc:deprecatedOn</h4> A <a rel="rdfs:domain"
 		                            href="#License">License</a> may be deprecated;
 	      provides the <a rel="rdfs:range"
-		              href="//www.w3.org/2001/XMLSchema-datatypes#date">date</a> <span property="rdfs:label">deprecated
+		              href="http://www.w3.org/2001/XMLSchema-datatypes#date">date</a> <span property="rdfs:label">deprecated
 		on</span>.
 	    </div>
 
@@ -295,9 +295,9 @@
 		license</span> a <a rel="rdfs:range"
 		                    href="#License">License</a>. <br />
 	      (a <a rel="rdfs:subPropertyOf"
-		    href="//purl.org/dc/terms/license">subproperty
+		    href="http://purl.org/dc/terms/license">subproperty
 		of dc:license</a>, <a rel="owl:sameAs"
-		                      href="//www.w3.org/1999/xhtml/vocab#license">the
+		                      href="http://www.w3.org/1999/xhtml/vocab#license">the
 		same as xhtml:license</a>)
 	      <span rev="owl:equivalentProperty"
 		    resource="http://web.resource.org/cc/license"></span>
@@ -329,7 +329,7 @@
 	    <div id="attributionURL" about="#attributionURL" 
 		 typeof="rdf:Property">
 	      <h4>cc:attributionURL</h4> The <a rel="rdfs:range"
-		                                href="//www.w3.org/2000/01/rdf-schema#Resource">
+		                                href="http://www.w3.org/2000/01/rdf-schema#Resource">
 		URL</a> the creator of a <a rel="rdfs:domain"
 		                            href="#Work">Work</a> would like used when
 	      attributing re-use.
@@ -364,13 +364,13 @@
             </ul>
 
             <p class="box">
-	      <a rel="license" href="//creativecommons.org/licenses/by/4.0/">
+	      <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
 	        <img src="//i.creativecommons.org/l/by/4.0/88x31.png" alt="Creative Commons License" style="border: medium none ;" height="31" width="88" />
 	      </a>
 	      Except where otherwise <a class="subfoot"
                                         href="/policies#license">noted</a>, content on this site is licensed
               under a <a rel="license"
-                         href="//creativecommons.org/licenses/by/4.0/"
+                         href="http://creativecommons.org/licenses/by/4.0/"
                          class="subfoot">Creative Commons Attribution 4.0 International license</a>
           </p></div>
 


### PR DESCRIPTION
that affect the generated RDF. This includes term definitions for CC as well as references to other vocabularies, where the URI scheme was mistakenly removed.

It seems that bulk changes were made to the document to make it compatible with whatever scheme it was loaded from, which included references to schema.org and dublin core vocabularies, which define their terms using the "http" scheme, not "https".

Changed the base declaration to us "http" instead of "https" so that term definitions for CC terms use the "http" scheme, as has always been the practice, and is documented on the wiki. Note that this also uses "http" scheme for the license URIs themselves, which was also historically used, but other wiki examples now use "https", so this could go either way. Personally, I go for consistency, and if you've indicated a license via a URI that was in the "http" scheme before, it is technically not the same as the same license using the "https" scheme, but this could be intentional.